### PR TITLE
Carts now use non-deprecated get_cart_url if available

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ function athena_setup() {
     
     
         if( !defined( 'ATHENA_VERSION' ) ) :
-            define('ATHENA_VERSION', '1.1.0');
+            define('ATHENA_VERSION', '1.1.1');
         endif;
     
         
@@ -42,6 +42,9 @@ function athena_setup() {
 	 */
 	add_theme_support( 'title-tag' );
         add_theme_support('woocommerce');
+        add_theme_support( 'wc-product-gallery-zoom' );
+        add_theme_support( 'wc-product-gallery-lightbox' );
+        add_theme_support( 'wc-product-gallery-slider' );
         add_editor_style('');
         
 	/*

--- a/header.php
+++ b/header.php
@@ -78,7 +78,7 @@
                                 
                                     <div class="athena-mobile-cart">
 
-                                        <a class="athena-cart" href="<?php echo WC()->cart->get_cart_url() ; ?>"><span class="fa fa-shopping-cart"></span> <?php echo WC()->cart->get_cart_total(); ?></a>
+                                        <a class="athena-cart" href="<?php echo function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : WC()->cart->get_cart_url(); ?>"><span class="fa fa-shopping-cart"></span> <?php echo WC()->cart->get_cart_total(); ?></a>
 
                                     </div>
                                 

--- a/inc/athena/athena.php
+++ b/inc/athena/athena.php
@@ -225,7 +225,7 @@ function athena_customize_nav($items) {
     endif;
     
     if( class_exists( 'WooCommerce' ) ) :
-        $items .= '<li><a class="athena-cart" href="' . WC()->cart->get_cart_url() . '"><span class="fa fa-shopping-cart"></span> ' . WC()->cart->get_cart_total() . '</a></li>';
+        $items .= '<li><a class="athena-cart" href="' . ( function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : WC()->cart->get_cart_url() ) . '"><span class="fa fa-shopping-cart"></span> ' . WC()->cart->get_cart_total() . '</a></li>';
     endif;
     
     

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Contributors: smartcat,automattic
 Tags: one-column,two-columns,three-columns,left-sidebar,right-sidebar,grid-layout,custom-colors,custom-logo,featured-images,footer-widgets,full-width-template,theme-options,translation-ready,portfolio,e-commerce,entertainment
 
 Requires at least: 4.6
-Tested up to: 4.7.4
-Stable tag: 1.1.0
+Tested up to: 4.8.2
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -71,6 +71,9 @@ Update tags
 updated TGM to latest version
 Bug fix for sidebar on Shop page
 
+= 1.1.1 - Oct 20th, 2017
+Reinstate WooCommerce Gallery features by specifically adding declarations
+Fix for deprecated get_cart_url() for WooCommerce
 
 == Credits ==
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://smartcatdesign.net/articles/athena-responsive-multipurpose-wo
 Author: Smartcat
 Author URI: https://smartcatdesign.net
 Description: Build your site Athena with ease. Athena is a feature-loaded, user-friendly, fully responsive, Parallax modern WordPress theme built with care and SEO in mind. It is a Woocommerce ready, multi-purpose theme with a design that can be used by a business, restaurant, freelancers, photographers, bloggers, musicians and creative agencies. Athena features a full width frontpage slider, animated callouts with over 600 icons to choose from. The blog is an attractive masonry grid. It comes with many color options, left and right sidebars, 6 widget areas, primary and footer menus, mobile responsive menu and links to your social media sites . Athena allows you to fully customize your site without having to work with code. Athena also features a live customizer, allowing you to change settings and preview them live. 
-Version: 1.1.0
+Version: 1.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: athena


### PR DESCRIPTION
To avoid WooCommerce PHP notice in newer versions